### PR TITLE
Adding Basic SPI Support Issue #17

### DIFF
--- a/initializations/init_gpio.c
+++ b/initializations/init_gpio.c
@@ -43,13 +43,13 @@ unsigned char init_gpio_spi(void){
         );
 
 
-    //P3.5,4,0 option select
-    /*
+    //option select input
+
     GPIO_setAsPeripheralModuleFunctionInputPin(
-        GPIO_PORT_P3,
-        GPIO_PIN1 + GPIO_PIN2 + GPIO_PIN3
+        GPIO_PORT_P1,
+        GPIO_PIN2
         );
-    */
+
 
     return 0;
 }

--- a/initializations/init_gpio.c
+++ b/initializations/init_gpio.c
@@ -1,0 +1,55 @@
+/*
+ * init_gpio.c
+ *
+ *  Created on: Feb 9, 2018
+ *      Author: KB1LQ
+ */
+
+#include "driverlib.h"
+#include "init_gpio.h"
+
+unsigned char init_gpio_spi(void){
+    /**
+     * SCLK = P1.4
+     * MISO = P1.2 (Needs pullup?)
+     * MOSI = P1.3 (Needs pullup?)
+     * CS   = P5.5
+     * HOLD = P5.6
+     */
+
+    //Set initial GPIO output values (Needed with ISCI B operation?)
+    // SCLK
+    GPIO_setOutputHighOnPin(
+        GPIO_PORT_P1,
+        GPIO_PIN4
+        );
+
+    // MOSI
+    GPIO_setOutputHighOnPin(
+        GPIO_PORT_P1,
+        GPIO_PIN3
+        );
+
+    // CS
+    GPIO_setOutputHighOnPin(
+        GPIO_PORT_P5,
+        GPIO_PIN5
+        );
+
+    // SCLK
+    GPIO_setOutputHighOnPin(
+        GPIO_PORT_P5,
+        GPIO_PIN6
+        );
+
+
+    //P3.5,4,0 option select
+    /*
+    GPIO_setAsPeripheralModuleFunctionInputPin(
+        GPIO_PORT_P3,
+        GPIO_PIN1 + GPIO_PIN2 + GPIO_PIN3
+        );
+    */
+
+    return 0;
+}

--- a/initializations/init_gpio.c
+++ b/initializations/init_gpio.c
@@ -17,18 +17,18 @@ unsigned char init_gpio_spi(void){
      * HOLD = P5.6
      */
 
-    //Set initial GPIO output values (Needed with ISCI B operation?)
-    // SCLK
-    GPIO_setOutputHighOnPin(
-        GPIO_PORT_P1,
-        GPIO_PIN4
-        );
-
-    // MOSI
-    GPIO_setOutputHighOnPin(
-        GPIO_PORT_P1,
-        GPIO_PIN3
-        );
+//    //Set initial GPIO output values (Needed with ISCI B operation?)
+//    // SCLK
+//    GPIO_setOutputHighOnPin(
+//        GPIO_PORT_P1,
+//        GPIO_PIN4
+//        );
+//
+//    // MOSI
+//    GPIO_setOutputHighOnPin(
+//        GPIO_PORT_P1,
+//        GPIO_PIN3
+//        );
 
     // CS
     GPIO_setOutputHighOnPin(
@@ -36,11 +36,11 @@ unsigned char init_gpio_spi(void){
         GPIO_PIN5
         );
 
-    // SCLK
-    GPIO_setOutputHighOnPin(
-        GPIO_PORT_P5,
-        GPIO_PIN6
-        );
+//    // SCLK
+//    GPIO_setOutputHighOnPin(
+//        GPIO_PORT_P5,
+//        GPIO_PIN6
+//        );
 
 
     //option select input
@@ -48,6 +48,12 @@ unsigned char init_gpio_spi(void){
     GPIO_setAsPeripheralModuleFunctionInputPin(
         GPIO_PORT_P1,
         GPIO_PIN2
+        );
+
+    //option select
+    GPIO_setAsPeripheralModuleFunctionOutputPin(
+        GPIO_PORT_P1,
+        GPIO_PIN3 + GPIO_PIN4
         );
 
 

--- a/initializations/init_gpio.h
+++ b/initializations/init_gpio.h
@@ -1,0 +1,22 @@
+/*
+ * init_gpio.h
+ *
+ *  Created on: Feb 9, 2018
+ *      Author: KB1LQ
+ */
+
+#ifndef INITIALIZATIONS_INIT_GPIO_H_
+#define INITIALIZATIONS_INIT_GPIO_H_
+
+/**
+ * This function initializes the CC430 GPIO for use with the USCI B peripheral
+ * hardware in SPI mode.
+ * @author Brenton Salmi, KB1LQD
+ * @return False
+ * @date 2/9/2018
+ */
+unsigned char init_gpio_spi(void);
+
+
+
+#endif /* INITIALIZATIONS_INIT_GPIO_H_ */

--- a/initializations/init_spi.c
+++ b/initializations/init_spi.c
@@ -1,0 +1,19 @@
+/*
+ * init_spi.c
+ *
+ *  Created on: Feb 9, 2018
+ *      Author: KB1LQ
+ */
+
+#include "driverlib.h"
+#include "init_spi.h"
+
+/**
+ * Specify desired frequency of SPI communication
+ */
+#define SPICLK                          500000
+
+uint8_t transmitData = 0x00;
+uint8_t receiveData = 0x00;
+uint8_t returnValue = 0x00;
+

--- a/initializations/init_spi.c
+++ b/initializations/init_spi.c
@@ -18,3 +18,35 @@ uint8_t receiveData = 0x00;
 uint8_t returnValue = 0x00;
 
 
+unsigned char init_spi(void){
+    //Initialize Master
+    USCI_B_SPI_initMasterParam param = {0};
+    param.selectClockSource = USCI_B_SPI_CLOCKSOURCE_SMCLK;
+    param.clockSourceFrequency = UCS_getSMCLK();
+    param.desiredSpiClock = SPICLK;
+    param.msbFirst = USCI_B_SPI_MSB_FIRST;
+    param.clockPhase = USCI_B_SPI_PHASE_DATA_CHANGED_ONFIRST_CAPTURED_ON_NEXT;
+    param.clockPolarity = USCI_B_SPI_CLOCKPOLARITY_INACTIVITY_HIGH;
+    returnValue =  USCI_B_SPI_initMaster(USCI_B0_BASE, &param);
+
+    if (STATUS_FAIL == returnValue){
+        return;
+    }
+
+    //Enable SPI module
+    USCI_B_SPI_enable(USCI_B0_BASE);
+
+    //Enable Receive interrupt
+    USCI_B_SPI_clearInterrupt(USCI_B0_BASE, USCI_B_SPI_RECEIVE_INTERRUPT);
+    USCI_B_SPI_enableInterrupt(USCI_B0_BASE, USCI_B_SPI_RECEIVE_INTERRUPT);
+
+    //Now with SPI signals initialized, reset slave
+    /*
+    GPIO_setOutputLowOnPin(
+        GPIO_PORT_P1,
+        GPIO_PIN1
+        );
+        */
+
+    return 0;
+}

--- a/initializations/init_spi.c
+++ b/initializations/init_spi.c
@@ -17,3 +17,4 @@ uint8_t transmitData = 0x00;
 uint8_t receiveData = 0x00;
 uint8_t returnValue = 0x00;
 
+

--- a/initializations/init_spi.c
+++ b/initializations/init_spi.c
@@ -30,7 +30,7 @@ unsigned char init_spi(void){
     returnValue =  USCI_B_SPI_initMaster(USCI_B0_BASE, &param);
 
     if (STATUS_FAIL == returnValue){
-        return;
+        return 1;
     }
 
     //Enable SPI module
@@ -47,6 +47,19 @@ unsigned char init_spi(void){
         GPIO_PIN1
         );
         */
+
+    //Wait for slave to initialize
+    __delay_cycles(100);
+
+    //Initialize data values
+    transmitData = 0x00;
+
+    //USCI_A0 TX buffer ready?
+    while (!USCI_B_SPI_getInterruptStatus(USCI_B0_BASE,
+               USCI_B_SPI_TRANSMIT_INTERRUPT)) ;
+
+    //Transmit Data to slave
+    USCI_B_SPI_transmitData(USCI_B0_BASE, transmitData);
 
     return 0;
 }

--- a/initializations/init_spi.c
+++ b/initializations/init_spi.c
@@ -40,26 +40,16 @@ unsigned char init_spi(void){
     USCI_B_SPI_clearInterrupt(USCI_B0_BASE, USCI_B_SPI_RECEIVE_INTERRUPT);
     USCI_B_SPI_enableInterrupt(USCI_B0_BASE, USCI_B_SPI_RECEIVE_INTERRUPT);
 
-    //Now with SPI signals initialized, reset slave
-    /*
-    GPIO_setOutputLowOnPin(
-        GPIO_PORT_P1,
-        GPIO_PIN1
-        );
-        */
-
-    //Wait for slave to initialize
-    __delay_cycles(100);
-
     //Initialize data values
     transmitData = 0x00;
 
-    //USCI_A0 TX buffer ready?
-    while (!USCI_B_SPI_getInterruptStatus(USCI_B0_BASE,
-               USCI_B_SPI_TRANSMIT_INTERRUPT)) ;
-
-    //Transmit Data to slave
-    USCI_B_SPI_transmitData(USCI_B0_BASE, transmitData);
+//    // Example Transmission
+//    //USCI_A0 TX buffer ready?
+//    while (!USCI_B_SPI_getInterruptStatus(USCI_B0_BASE,
+//               USCI_B_SPI_TRANSMIT_INTERRUPT)) ;
+//
+//    //Transmit Data to slave
+//    USCI_B_SPI_transmitData(USCI_B0_BASE, transmitData);
 
     return 0;
 }

--- a/initializations/init_spi.h
+++ b/initializations/init_spi.h
@@ -1,0 +1,28 @@
+/*
+ * init_spi.h
+ *
+ *  Created on: Feb 9, 2018
+ *      Author: KB1LQ
+ */
+
+#ifndef INITIALIZATIONS_INIT_SPI_H_
+#define INITIALIZATIONS_INIT_SPI_H_
+
+/**
+ * Transmit data byte value
+ */
+extern uint8_t transmitData;
+
+/**
+ * Receive data byte value
+ */
+extern uint8_t receiveData;
+
+/**
+ * Return byte data byte value
+ */
+extern uint8_t returnValue;
+
+
+
+#endif /* INITIALIZATIONS_INIT_SPI_H_ */

--- a/initializations/init_spi.h
+++ b/initializations/init_spi.h
@@ -23,6 +23,15 @@ extern uint8_t receiveData;
  */
 extern uint8_t returnValue;
 
+/**
+ * This function initializes the CC430 SPI hardware on the USCI B peripheral
+ * hardware in SPI mode.
+ * @author Brenton Salmi, KB1LQD
+ * @return False
+ * @date 2/9/2018
+ */
+unsigned char init_spi(void);
+
 
 
 #endif /* INITIALIZATIONS_INIT_SPI_H_ */

--- a/main.c
+++ b/main.c
@@ -41,6 +41,8 @@
 
 #include "driverlib.h"
 #include "initializations/init_ucs.h" // @TODO Make this a project global initialization directory for the linker.
+#include "initializations/init_spi.h" // @TODO Make this a project global initialization directory for the linker.
+#include "initializations/init_gpio.h" // @TODO Make this a project global initialization directory for the linker.
 
 /**
  * This function is the main function of the program. It contains an infinite
@@ -56,6 +58,10 @@ void main (void)
 
     //Initialize UCS to 12MHz
     initialize_ucs();
+
+    //Initialize SPI
+    init_gpio_spi();
+    init_spi();
 
 
     // Enable global interrupt

--- a/main.c
+++ b/main.c
@@ -117,8 +117,9 @@ void USCI_B0_ISR (void)
     switch (__even_in_range(UCB0IV,4)){
         //Vector 2 - RXIFG
         case 2:
+            __no_operation();
             //USCI_A0 TX buffer ready?
-            /*
+
             while (!USCI_B_SPI_getInterruptStatus(USCI_B0_BASE,
                        USCI_B_SPI_TRANSMIT_INTERRUPT)) ;
 
@@ -134,7 +135,7 @@ void USCI_B0_ISR (void)
 
             //Delay between transmissions for slave to process information
             __delay_cycles(40);
-            */
+
 
             break;
         default: break;

--- a/main.c
+++ b/main.c
@@ -93,3 +93,44 @@ void NMI_ISR(void)
     __no_operation();
   } while(status != 0);
 }
+
+
+/**
+ * This is the USCI_B0 interrupt vector service routine.
+ * @author Brenton Salmi, KB1LQD
+ * @date 2/9/2018
+ */
+#if defined(__TI_COMPILER_VERSION__) || defined(__IAR_SYSTEMS_ICC__)
+#pragma vector=USCI_B0_VECTOR
+__interrupt
+#elif defined(__GNUC__)
+__attribute__((interrupt(USCI_B0_VECTOR)))
+#endif
+void USCI_B0_ISR (void)
+{
+    switch (__even_in_range(UCB0IV,4)){
+        //Vector 2 - RXIFG
+        case 2:
+            //USCI_A0 TX buffer ready?
+            /*
+            while (!USCI_B_SPI_getInterruptStatus(USCI_B0_BASE,
+                       USCI_B_SPI_TRANSMIT_INTERRUPT)) ;
+
+            receiveData = USCI_B_SPI_receiveData(USCI_B0_BASE);
+
+            //Increment data
+            transmitData++;
+
+            //Send next value
+            USCI_B_SPI_transmitData(USCI_B0_BASE,
+            transmitData
+            );
+
+            //Delay between transmissions for slave to process information
+            __delay_cycles(40);
+            */
+
+            break;
+        default: break;
+    }
+}

--- a/main.c
+++ b/main.c
@@ -67,6 +67,18 @@ void main (void)
     // Enable global interrupt
     __bis_SR_register(GIE);
 
+    //Test
+    //USCI_A0 TX buffer ready?
+    unsigned char i;
+    for(i=0;i<256;i++){
+        while (!USCI_B_SPI_getInterruptStatus(USCI_B0_BASE,
+                   USCI_B_SPI_TRANSMIT_INTERRUPT)) ;
+
+        //Transmit Data to slave
+        transmitData = i;
+        USCI_B_SPI_transmitData(USCI_B0_BASE, transmitData);
+    }
+
     // Infinite main loop
     while(1){
 
@@ -117,21 +129,12 @@ void USCI_B0_ISR (void)
     switch (__even_in_range(UCB0IV,4)){
         //Vector 2 - RXIFG
         case 2:
-            __no_operation();
             //USCI_A0 TX buffer ready?
-
             while (!USCI_B_SPI_getInterruptStatus(USCI_B0_BASE,
                        USCI_B_SPI_TRANSMIT_INTERRUPT)) ;
 
+            //Copy received byte buffer into global variable
             receiveData = USCI_B_SPI_receiveData(USCI_B0_BASE);
-
-            //Increment data
-            transmitData++;
-
-            //Send next value
-            USCI_B_SPI_transmitData(USCI_B0_BASE,
-            transmitData
-            );
 
             //Delay between transmissions for slave to process information
             __delay_cycles(40);


### PR DESCRIPTION
Adding basic SPI support using driverlib. No support for specific slave devices has been made and that will be added in future pull requests which may also add to the base SPI support. This PR has been shown to produce expected SPI signals on an oscilloscope although tuning on phase/polarity may be needed for specific slave devices.